### PR TITLE
Stdout as metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,11 @@ Options:
   --service=SERVICE     An optional service to the event. Defaults to the
                         basename of the command that's run
   --debug               Output the event before it's sent to Riemann.
+  --stdout              Use std as the metric, rather than elapsed time.
 ````
     
 `run-and-report.py` will run the command string and report that the event occurred.
-The time it took to run the command will be the metric of th event.
+The time it took to run the command will be the metric of the event, unless overridden by `--stdout`
 The states argument defines the state of the event based on the return code of the command.
     
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Options:
   --service=SERVICE     An optional service to the event. Defaults to the
                         basename of the command that's run
   --debug               Output the event before it's sent to Riemann.
-  --stdout              Use std as the metric, rather than elapsed time.
+  --stdout              Use stdout as the metric, rather than elapsed command walltime.
 ````
     
 `run-and-report.py` will run the command string and report that the event occurred.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Options:
   --service=SERVICE     An optional service to the event. Defaults to the
                         basename of the command that's run
   --debug               Output the event before it's sent to Riemann.
-  --stdout              Use stdout as the metric, rather than elapsed command walltime.
+  --metric-from-stdout  Use stdout as the metric, rather than elapsed command walltime.
 ````
     
 `run-and-report.py` will run the command string and report that the event occurred.

--- a/run-and-report.py
+++ b/run-and-report.py
@@ -94,7 +94,7 @@ if __name__ == "__main__":
     if options.ttl:
         riemann_event["ttl"] = int(options.ttl)
     riemann_event["host"]  = socket.gethostname()
-    if options.stdout:
+    if options.metric_from_stdout:
         riemann_event["metric"] = float(stdout)
     else:
         riemann_event["metric"] = duration

--- a/run-and-report.py
+++ b/run-and-report.py
@@ -55,7 +55,7 @@ if __name__ == "__main__":
     parser.add_option("--states", default="ok:0", help="Describes a mapping of return codes and event states.  e.g. ok:0,1|warn:2,3. Return codes without an explicit mapping are assumed error. default=ok:0")
     parser.add_option("--service", default=None, help="An optional service to the event. Defaults to the basename of the command that's run")
     parser.add_option("--debug", default=False, action='store_true', help="Output the event before it's sent to Riemann.")
-    parser.add_option("--stdout", default=False, action='store_true', help="Use stdout as the metric rather than the command clocktime.")
+    parser.add_option("--stdout", default=False, action='store_true', help="Use stdout as the metric rather than the elapsed command walltime.")
 
     options, command = parser.parse_args()
     if not command:

--- a/run-and-report.py
+++ b/run-and-report.py
@@ -55,7 +55,7 @@ if __name__ == "__main__":
     parser.add_option("--states", default="ok:0", help="Describes a mapping of return codes and event states.  e.g. ok:0,1|warn:2,3. Return codes without an explicit mapping are assumed error. default=ok:0")
     parser.add_option("--service", default=None, help="An optional service to the event. Defaults to the basename of the command that's run")
     parser.add_option("--debug", default=False, action='store_true', help="Output the event before it's sent to Riemann.")
-    parser.add_option("--stdout", default=False, action='store_true', help="Use stdout as the metric rather than the elapsed command walltime.")
+    parser.add_option("--metric-from-stdout", default=False, action='store_true', help="Use stdout as the metric rather than the elapsed command walltime.")
 
     options, command = parser.parse_args()
     if not command:

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 from distutils.core import setup
 
-version = "0.2.1"
+version = "0.3.0"
 
 setup(name="run-and-report",
       version=version,


### PR DESCRIPTION
Adds a --stdout flag to send stdout as the metric, rather than the elapsed time of the command.

User will then be able to run arbitrary commands and send response back as the metric to riemann to be processed.
